### PR TITLE
feat: 新增 Steam 游戏状态与绑定卡片渲染功能

### DIFF
--- a/nonebot_plugin_steam_game_status/templates/steam_bind_card.html
+++ b/nonebot_plugin_steam_game_status/templates/steam_bind_card.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body {
+            margin: 0;
+            padding: 10px;
+            background-color: transparent;
+            font-family: "Microsoft YaHei", "Arial", sans-serif;
+            width: fit-content;
+        }
+
+        .bind-card {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            /* 竖向卡片，背景色稍亮一些 */
+            background: linear-gradient(180deg, #171a21 0%, #2a475e 100%);
+            width: 300px;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 8px 20px rgba(0, 0, 0, 0.6);
+            border: 1px solid #66c0f4; /* Steam 蓝色边框表示选中/绑定 */
+            position: relative;
+            overflow: hidden;
+        }
+
+        /* 顶部标题 */
+        .title {
+            font-size: 18px;
+            color: #66c0f4;
+            letter-spacing: 2px;
+            margin-bottom: 20px;
+            font-weight: bold;
+            text-transform: uppercase;
+            border-bottom: 2px solid #66c0f4;
+            padding-bottom: 5px;
+        }
+
+        /* 头像区域 */
+        .avatar-box {
+            position: relative;
+            margin-bottom: 15px;
+        }
+
+        .avatar {
+            width: 120px;
+            height: 120px;
+            border-radius: 50%; /* 圆形头像 */
+            border: 4px solid #fff;
+            box-shadow: 0 0 15px rgba(102, 192, 244, 0.4);
+            display: block;
+        }
+
+        /* 玩家名字 */
+        .player-name {
+            font-size: 24px;
+            font-weight: bold;
+            color: #ffffff;
+            margin-bottom: 5px;
+            text-align: center;
+            width: 100%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        /* Steam ID */
+        .steam-id {
+            font-size: 14px;
+            color: #c6d4df;
+            background-color: rgba(0, 0, 0, 0.3);
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-family: monospace;
+        }
+
+        /* 底部提示 */
+        .footer {
+            margin-top: 20px;
+            font-size: 12px;
+            color: #8f98a0;
+        }
+
+        /* 背景装饰 */
+        .bg-icon {
+            position: absolute;
+            top: -20px;
+            left: -20px;
+            font-size: 150px;
+            color: rgba(255, 255, 255, 0.03);
+            pointer-events: none;
+            z-index: 0;
+            transform: rotate(25deg);
+        }
+    </style>
+</head>
+<body>
+    <div class="bind-card">
+        <div class="bg-icon">#</div>
+        <div class="title">绑定成功</div>
+
+        <div class="avatar-box">
+            <img
+                src="{{ avatar_url }}"
+                onerror="this.onerror=null;this.src='data:image/svg+xml;charset=utf-8,%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 viewBox%3D%220 0 100 100%22%3E%3Crect width%3D%22100%25%22 height%3D%22100%25%22 fill%3D%22%232a475e%22%2F%3E%3Ctext x%3D%2250%25%22 y%3D%2250%25%22 dominant-baseline%3D%22middle%22 text-anchor%3D%22middle%22 font-family%3D%22Microsoft YaHei%22 font-size%3D%2230%22 fill%3D%22%238f98a0%22%3E头像%3C%2Ftext%3E%3C%2Fsvg%3E';this.style.padding='0';this.style.objectFit='cover';"
+                class="avatar"
+            >
+        </div>
+
+        <div class="player-name">{{ player_name }}</div>
+        <div class="steam-id">ID: {{ steam_id }}</div>
+
+        <div class="footer">现在可以追踪你的游戏状态了</div>
+    </div>
+</body>
+</html>

--- a/nonebot_plugin_steam_game_status/templates/steam_card.html
+++ b/nonebot_plugin_steam_game_status/templates/steam_card.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <style>
+
+        body {
+            margin: 0;
+            padding: 35px;
+            background-color: transparent;
+            font-family: "Microsoft YaHei", "Arial", sans-serif;
+            width: fit-content;
+        }
+
+        /* 卡片 */
+        .steam-card {
+            display: flex;
+            align-items: center;
+            /* Steam 经典深色 */
+            background: linear-gradient(135deg, #1b2838 0%, #171a21 100%);
+            padding: 12px;
+            border-radius: 4px;
+            width: 400px; /* 固定宽度，可做适当修改 */
+            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.5);
+            border: 1px solid #2a475e;
+            position: relative;
+            overflow: hidden;
+        }
+
+
+        .avatar-box {
+            position: relative;
+            margin-right: 16px;
+            flex-shrink: 0;
+        }
+
+        .avatar {
+            width: 74px;
+            height: 74px;
+            border-radius: 4px;
+            display: block;
+        }
+
+
+        .avatar-border {
+            position: absolute;
+            top: -3px; left: -3px; right: -3px; bottom: -3px;
+            border: 3px solid #90ba3c;
+            border-radius: 6px;
+            pointer-events: none;
+        }
+
+
+        .info-box {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            z-index: 2;
+            max-width: 340px;
+        }
+
+
+        .player-name {
+            font-size: 22px;
+            font-weight: bold;
+            color: #90ba3c;
+            margin-bottom: 2px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+
+        .action-text {
+            font-size: 14px;
+            color: #c6d4df;
+            margin-bottom: 4px;
+        }
+
+
+        .game-name {
+            font-size: 18px;
+            color: #ffffff;
+            font-weight: 500;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            text-shadow: 0 1px 2px black;
+        }
+
+        /* 背景装饰水印Steam效果 */
+        .bg-watermark {
+            position: absolute;
+            right: -20px;
+            bottom: -30px;
+            font-size: 140px;
+            font-weight: bold;
+            color: rgba(255, 255, 255, 0.03); /* 调整的话改此透明度 */
+            transform: rotate(-10deg);
+            pointer-events: none;
+            user-select: none;
+            z-index: 1;
+        }
+    </style>
+</head>
+<body>
+    <div class="steam-card">
+        <div class="bg-watermark">Steam</div>
+
+        <div class="avatar-box">
+            <img
+                src="{{ avatar_url }}"
+                onerror="this.onerror=null;this.src='data:image/svg+xml;charset=utf-8,%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 viewBox%3D%220 0 100 100%22%3E%3Crect width%3D%22100%25%22 height%3D%22100%25%22 fill%3D%22%232a475e%22%2F%3E%3Ctext x%3D%2250%25%22 y%3D%2250%25%22 dominant-baseline%3D%22middle%22 text-anchor%3D%22middle%22 font-family%3D%22Microsoft YaHei%22 font-size%3D%2230%22 fill%3D%22%238f98a0%22%3E头像%3C%2Ftext%3E%3C%2Fsvg%3E';this.style.padding='0';this.style.objectFit='cover';"
+                class="avatar"
+                alt="avatar"
+            >
+            <div class="avatar-border"></div>
+        </div>
+
+        <div class="info-box">
+            <div class="player-name">{{ player_name }}</div>
+            <div class="action-text">{{ action_text }}</div>
+            <div class="game-name">{{ game_name }}</div>
+        </div>
+    </div>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,8 @@ Repository = "https://github.com/nek0us/nonebot_plugin_steam_game_status"
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"
+
+[tool.pdm.build]
+includes = [
+    "nonebot_plugin_steam_game_status",
+]


### PR DESCRIPTION
## ✨ 新功能
使用图片展示绑定成功、游戏状态：
<img width="495" height="944" alt="image" src="https://github.com/user-attachments/assets/4c904101-bc1b-47c4-a770-541b509c5544" />

## 📝 新文件
- `templates`下添加了两个html文件作为图片渲染模板
- 在`pyproject.toml`中添加了以下内容确保html文件被打包发布：
```toml
[tool.pdm.build]
includes = [
    "nonebot_plugin_steam_game_status",
]
```
我此前使用setuptool时，需要标记html这类静态文件以确保其被打包，**我几乎没用过pdm,不知道要包含静态文件是否需要添加此配置项，请核实**

## 🏗️ 代码调整
- 修改 `__init__.py`，新增 `render_steam_card` 和 `render_bind_card`
- 在 `get_status` 定时任务中，检测到状态变化时优先尝试渲染图片发送
- 在 `steam_bind_handle` 指令中，绑定成功后尝试渲染图片发送


## 📦 依赖
[nonebot-plugin-htmlrender](https://github.com/kexue-z/nonebot-plugin-htmlrender) （项目已包含）


## 🚧 测试

- 绑定指令：正常发送绑定成功卡片，头像显示正常
- 状态播报：当好友开始游戏/停止游戏时，能发送渲染好的状态卡片
- 异常测试：模拟头像 加载不出来，卡片显示预设的占位样式（文字“头像”）
- 降级测试：模拟渲染失败，成功发送原来的文本消息

**只测试了`开始玩`、`玩了xx后停止`、`结束了游戏`**，都正常显示
